### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/jfscan-up/security/code-scanning/15](https://github.com/deadjdona/jfscan-up/security/code-scanning/15)

In general, the fix is to explicitly declare a `permissions:` block in the workflow to restrict the `GITHUB_TOKEN` to the minimal scopes needed. For this pylint workflow, it only needs to read repository contents to check out and lint code; no write operations are performed. Therefore, setting `permissions: contents: read` at the workflow root is sufficient and will apply to all jobs that don’t override it.

The best fix without changing functionality is to add a top-level `permissions:` block right after the `name:` (or `on:`) section in `.github/workflows/pylint.yml`. This keeps the behavior identical while constraining the token. No additional imports, steps, or changes to existing steps are required. Specifically, add:

```yaml
permissions:
  contents: read
```

at the root level (same indentation as `on:` and `jobs:`). No other files or regions need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
